### PR TITLE
Cleanup of describe_vpcs.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # tools
-Useful tools
+Provides some useful scripts for common chores.
+
+## describe_vpcs.rb
+
+This ruby script will scrape your AWS account for vpc and, optionally, subnet information and outputs `terraform` variable maps. These are useful if you are working with an existing AWS infrastructure that is not managed by `terraform` and do not wish to import your existing vpcs or subnets. It requires a region as an argument passed to the `-r` flag. Without any additional arguments, it will map all existing vpcs that it finds:
+
+```
+[brukbook.local:~] brukshut% ./describe_vpcs.rb -r us-west-1
+
+variable "vpcs" {
+  type = "map"
+
+  default = {
+    bruknet = "vpc-023asdfcbc70c9e" // (10.0.0.0/22)
+  }
+}
+```
+If you pass the name of the vpc, or a csv separated list of vpcs, it will generate map variables for public and private subnets for those vpcs:
+```
+[brukbook.local:~] brukshut% describe_vpcs.rb -r us-west-1 -n bruknet
+variable "vpcs" {
+  type = "map"
+
+  default = {
+    bruknet = "vpc-023asdfcbc70c9e" // (10.0.0.0/22)
+  }
+}
+
+variable "public_subnets" {
+  type = "map"
+
+  default = {
+    bruknet-public-1 = "subnet-0222348b9d00bdd56" // bruknet us-west-1a (10.0.0.0/24)
+    bruknet-public-2 = "subnet-033234cb1fba656ab" // bruknet us-west-1a (10.0.1.0/24)
+  }
+}
+
+variable "private_subnets" {
+  type = "map"
+
+  default = {
+    bruknet-private-1 = "subnet-0asdff7a753bac2c" // bruknet us-west-1a (10.0.2.0/24)
+    bruknet-private-2 = "subnet-0asdf2248de5ae93" // bruknet us-west-1a (10.0.3.0/24)
+  }
+}
+```

--- a/describe_vpcs.rb
+++ b/describe_vpcs.rb
@@ -18,6 +18,27 @@ require 'aws-sdk-ec2'
 require 'pp'
 
 ## methods
+## initialize aws ec2 resource
+def ec2_resource(region)
+  begin
+    ec2 = Aws::EC2::Resource.new(region: region)
+  rescue => e
+    puts e
+    exit
+  end
+end
+
+## initialize aws ec2 client
+def ec2_client(region)
+  begin
+    client = Aws::EC2::Client.new(region: region)
+  rescue => e
+    puts e
+    exit
+  end
+end
+
+## return list of all vpcs
 def get_all_vpcs(ec2)
   all_vpcs = {}
   ec2.vpcs.each do |vpc|
@@ -34,6 +55,7 @@ def get_all_vpcs(ec2)
   all_vpcs
 end
 
+## get list of subnets for a vpc
 def get_vpc_subnets(client, vpc_id)
   resp = client.describe_subnets({
     filters: [{
@@ -43,6 +65,7 @@ def get_vpc_subnets(client, vpc_id)
   })
 end
 
+## sort and return public or private subnets
 def get_subnets(client, vpc_id, vpc_name, subnet_type, subnet_hash)
   resp = get_vpc_subnets(client, vpc_id)
   resp.subnets.each do |subnet|
@@ -89,6 +112,33 @@ def print_subnets(name, subnet_hash)
     print_footer
   end
 end
+
+def print_vpcs(all_vpcs)
+  print_header('vpcs')
+  all_vpcs.each do |vpc_name, vpc_data|
+    printf "    %s = \"%s\" // (%s)\n", vpc_name, vpc_data['vpc_id'], vpc_data['cidr_block']
+  end
+  print_footer
+end
+
+def print_vpc_subnets(vpc_list, all_vpcs, client)
+  public_subnets = {}
+  private_subnets = {}
+  ## map vpc(s)
+  print_header('vpcs')
+  vpc_names = []
+  vpc_names = vpc_list.split(",")
+  vpc_names.each do |vpc_name|
+    vpc_id = all_vpcs[vpc_name]['vpc_id']
+    public_subnets  = get_subnets(client, vpc_id, vpc_name, "public", public_subnets)
+    private_subnets = get_subnets(client, vpc_id, vpc_name, "private", private_subnets)
+    printf "    %s = \"%s\" // (%s)\n", vpc_name, all_vpcs[vpc_name]['vpc_id'], all_vpcs[vpc_name]['cidr_block']
+  end
+  print_footer
+  ## map subnets
+  print_subnets('public_subnets', public_subnets)
+  print_subnets('private_subnets', private_subnets)
+end
 ## end methods
 
 ## main
@@ -115,47 +165,21 @@ if options[:region].nil?
   exit
 end
 
-## inialize aws resource and client
-
-begin
-  ec2 = Aws::EC2::Resource.new(region: options[:region])
-rescue => e
-  puts e
-  exit
-end
-
-
-client = Aws::EC2::Client.new(region: options[:region])
-
-## hashes
-all_vpcs = Hash.new
-public_subnets = Hash.new
-private_subnets = Hash.new
+## connect
+ec2 = ec2_resource(options[:region])
+client = ec2_client(options[:region])
 
 ## get all vpcs
+all_vpcs = {}
 all_vpcs = get_all_vpcs(ec2)
 
-print_header('vpcs')
-if options[:name].nil?   
-  all_vpcs.each do |vpc_name, vpc_data|
-    printf "    %s = \"%s\" // (%s)\n", vpc_name, vpc_data['vpc_id'], vpc_data['cidr_block']
-  end
-else
-  vpc_names = []
-  vpc_names = options[:name].split(",")
-  vpc_names.each do |vpc_name|
-    vpc_id = all_vpcs[vpc_name]['vpc_id']
-    # def get_subnets(client, vpc_id, vpc_name, subnet_type, subnet_hash)
-    public_subnets  = get_subnets(client, vpc_id, vpc_name, "public", public_subnets)
-    private_subnets = get_subnets(client, vpc_id, vpc_name, "private", private_subnets)
-    printf "    %s = \"%s\" // (%s)\n", vpc_name, all_vpcs[vpc_name]['vpc_id'], all_vpcs[vpc_name]['cidr_block']
-  end
-end
-print_footer
+## map all vpcs without subnets
+print_vpcs(all_vpcs) if options[:name].nil?
 
-## print public_subnets
-print_subnets('public_subnets', public_subnets)
+## map (csv list of) vpc(s) and their public and private subnets
+print_vpc_subnets(options[:name], all_vpcs, client) if options[:name]
 
-## print private_subnets
-print_subnets('private_subnets', private_subnets)
+## end main
+
+
 


### PR DESCRIPTION
- provides improved `cleanup_vpcs.rb` ruby script to generate `terraform` map variables from existing aws vpcs and subnets that are not managed by `terraform`
- added a note to the README demonstrating its use.