### PR TITLE
make_cert.sh improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ variable "private_subnets" {
   }
 }
 ```
+
+## make_cert.sh
+
+Generates a 4096 bit rsa key, a certificate signing request and a self signed certificate. Requires a common name.
+
+```
+[brukbook.local:~] brukshut% ./make_cert.sh
+Usage: ./make_cert.sh -c [commonname]
+```

--- a/make_cert.sh
+++ b/make_cert.sh
@@ -4,27 +4,51 @@
 ## make_cert.sh
 ## simple shell script to generate self signed SSL certificate
 ##
-USAGE="Usage: $0 [server.common.name]"
 
-if [ $# == 0 ]; then
-  echo ${USAGE}
-  exit 1
-fi
-
-COMMONNAME=$1
-PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-export PATH
-
-#openssl genrsa -des3 -passout pass:x -out ${COMMONNAME}.secure.key 2048
-#openssl rsa -passin pass:x -in server.pass.key -out server.key
-
-## create secure key
-openssl genrsa -des3 -out ${COMMONNAME}.secure.key 2048
-## decrypt secure key to create public key
-openssl rsa -in ${COMMONNAME}.secure.key -out ${COMMONNAME}.key  
+## functions
+## create secuire and 
+function generate_key {
+  local cn=$1
+  openssl genrsa -out ${cn}.secure.key 4096
+  ## decrypt secure key to create public key
+  openssl rsa -in ${cn}.secure.key -out ${cn}.key
+}
 
 ## generate csr
-openssl req -new -key ${COMMONNAME}.secure.key -out ${COMMONNAME}.csr
+function generate_csr {
+  local cn=$1
+  openssl req -new -key ${cn}.secure.key -out ${cn}.csr
+}
 
 ## generate crt
-openssl x509 -req -days 365 -in ${COMMONNAME}.csr -signkey ${COMMONNAME}.key -out ${COMMONNAME}.crt
+function generate_crt {
+  local cn=$1
+  openssl x509 -req -days 365 -in ${cn}.csr -signkey ${cn}.key -out ${cn}.crt
+}
+
+function usage() {
+  echo "Usage: $0 -c [commonname]" && exit 1
+}
+## end functions
+
+## main
+PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+
+while getopts ":c:" opt; do
+  case $opt in
+    c) COMMONNAME=${OPTARG}
+      ;;
+    *) usage
+      ;;
+  esac
+done
+
+## require common name
+[[ -z $COMMONNAME ]] && usage ||
+  ( [[ -d $COMMONNAME ]] || mkdir ${COMMONNAME}
+    cd $COMMONNAME
+    generate_key $COMMONNAME
+    generate_csr $COMMONNAME
+		generate_crt $COMMONNAME )
+
+## end main


### PR DESCRIPTION
- provides improved `make_cert.sh`, used to generate self signed certificates
- uses 4096 bit rsa key